### PR TITLE
feat: support dynamic module loading for shared libraries in chat server

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -107,6 +107,7 @@ module.exports = {
         'object-curly-spacing': ['error', 'always'],
         'node/no-missing-import': 'off',
         'node/no-empty-function': 'off',
+        'node/no-unpublished-import': ['error', { ignorePatterns: '**/__tests__' }],
         'node/no-unsupported-features/es-syntax': 'off',
         'node/no-missing-require': 'off',
         'node/shebang': 'off',

--- a/__tests__/__src__/types/MockWrapper.ts
+++ b/__tests__/__src__/types/MockWrapper.ts
@@ -1,0 +1,53 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+/**
+ * Wraps an object with each key being a jest.Mock object. Should be used for getting
+ * easier types of jest mock objects in unit tests.
+ */
+export type MockWrapper<T> = {
+  [M in keyof T]: jest.Mock<T[M]>;
+};
+
+/**
+ * This function takes an object passed into it and converts the type to a {@link MockWrapper}.
+ *
+ * @param mock The object consisting of jest mocks.
+ *
+ * @returns The same object but each key typed as a mock.
+ *
+ * @example <caption>Proper Usage</caption>
+ *
+ * // In your test, there should be some jest mocks
+ * jest.mock("./path/goes/here/Module1");
+ * jest.mock("./path/goes/here/Module2");
+ *
+ * import {Module1} from "./path/goes/here/Module1";
+ * import {Module2} from "./path/goes/here/Module2";
+ * import {Module3} from "./path/goes/here/Module3";
+ *
+ * const mockObject = getMockWrapper({
+ *    module1Function1: Module1.function1,
+ *    module1Function2: Module1.function2,
+ *    module2: Module2
+ * });
+ *
+ * // Typescript will now accept the following syntax.
+ * mockObject.module2.mockImplementation(() => {
+ *     console.log("Implementation can be mocked");
+ * });
+ * mockObject.module1Function1.mocks.clear();
+ *
+ * Module1.function2("hooray proper types");
+ * expect(module1Function2.mocks.calls[0][0]).toBe("hooray proper types");
+ */
+export function getMockWrapper<T extends object>(mock: T): MockWrapper<T> {
+  return mock as MockWrapper<T>;
+}

--- a/__tests__/__src__/util/TestUtilities.ts
+++ b/__tests__/__src__/util/TestUtilities.ts
@@ -1,0 +1,28 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+/**
+ *
+ * @param {number} length - how long should the string be
+ * @param {boolean} upToLength -  if true, length is the maximum length of the string.
+ *                               (generate a string 'up to' length characters long)
+ * @returns {string} the random string
+ */
+export function generateRandomAlphaNumericString(length: number, upToLength = false): string {
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let result = '';
+  if (upToLength) {
+    length = Math.floor(Math.random() * length) + 1;
+  }
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * characters.length));
+  }
+  return result;
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -30,6 +30,7 @@ const config: Config = {
   globals: {
     'ts-jest': {
       disableSourceMapSupport: true,
+      config: 'tsconfig.tests.json',
     },
   },
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -32299,6 +32299,7 @@
       "dependencies": {
         "@zowe/core-for-zowe-sdk": "^7.2.2",
         "@zowe/zos-console-for-zowe-sdk": "^7.2.2",
+        "@zowe/zos-files-for-zowe-sdk": "^7.2.2",
         "@zowe/zos-jobs-for-zowe-sdk": "^7.2.2",
         "@zowe/zosmf-for-zowe-sdk": "^7.2.2"
       },
@@ -32327,7 +32328,6 @@
       "peerDependencies": {
         "@zowe/chat": "*",
         "@zowe/imperative": "*",
-        "@zowe/zos-files-for-zowe-sdk": "*",
         "i18next": "*"
       }
     }
@@ -36217,6 +36217,7 @@
         "@typescript-eslint/parser": ">=5.40.1",
         "@zowe/core-for-zowe-sdk": "^7.2.2",
         "@zowe/zos-console-for-zowe-sdk": "^7.2.2",
+        "@zowe/zos-files-for-zowe-sdk": "^7.2.2",
         "@zowe/zos-jobs-for-zowe-sdk": "^7.2.2",
         "@zowe/zosmf-for-zowe-sdk": "^7.2.2",
         "eslint": ">=8.26.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "updateDeps": "npx npm-check-updates -u",
     "updateDepsAll": "npm run updateDeps --workspaces",
     "lintAll": "npm run lint --workspaces",
-    "buildAll": "gulp updateLicense && npm run build --workspaces",
+    "buildAll": "npm run build --workspaces",
     "checkDepsAll": "npm run checkDeps --workspaces",
     "test:unit": "jest \"__tests__.*?__unit__.*\\.(spec|test)\\.tsx?$\" --coverage ",
     "test:integration": "jest \"__tests__.*?__integration__.*\\.(spec|test)\\.tsx?$\" --coverage false",

--- a/packages/chat/__tests__/plugins/__unit__/PluginRequireProvider.test.ts
+++ b/packages/chat/__tests__/plugins/__unit__/PluginRequireProvider.test.ts
@@ -1,0 +1,385 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+// eslint-disable-next-line node/no-unpublished-import
+import { PluginRequireProvider } from '../../../src/plugins/PluginRequireProvider';
+import * as PluginErrors from '../../../src/plugins/PluginErrors';
+// @ts-ignore
+import Module = require("module");
+
+import { generateRandomAlphaNumericString } from '../../../../../__tests__/__src__/util/TestUtilities';
+
+describe('PluginRequireProvider', () => {
+  /**
+   * This is an indicator that helps our require method to determine if a require
+   * for testing purposes only.
+   *
+   * @example <caption>Passing to a mocked require</caption>
+   *
+   * // Assume that all setup has been done
+   * // Use Module.prototype.require because jest intercepts the real require call.
+   * const moduleRequired = (Module.prototype.require as any).call("some_value", request, testRequireIndicator);
+   *
+   * // At this point moduleRequired should equal some_value if all went well.
+   */
+  const testRequireIndicator = '__TEST_REQUIRE__';
+
+  /**
+   * Object that allows access to internals of the PluginRequireProvider.
+   */
+  const mPluginRequireProvider: {
+    mInstance: {
+      origRequire: typeof Module.prototype.require;
+      modules: string[];
+      regex: RegExp;
+    };
+    sanitizeExpression: (module: string) => string;
+  } = PluginRequireProvider as any;
+
+  /**
+   * This gives us type access to the Module.prototype methods used in the tests.
+   */
+  const modulePrototype: {
+    require: (module: string, check: typeof testRequireIndicator) => any;
+  } = Module.prototype as any;
+
+
+  /**
+   * Stores the original require passed at the beginning of testing.
+   */
+  let originalRequire: typeof Module.prototype.require;
+
+  /**
+   * This check is done in both the beforeEach and afterEach sections of the tests. I decided to
+   * do it this way so that once a test fails, all other tests from this suite
+   * should fail. This should protect the real Module.prototype.require from
+   * being obliterated because of something we've done to cause a test to fail.
+   *
+   * @throws An error when the environment is not in a clean state.
+   */
+  const checkForCleanEnvironment = (isAfterEach = false) => {
+    try {
+      expect(mPluginRequireProvider.mInstance).toBeUndefined();
+    } catch (e) {
+      throw new Error(
+        (isAfterEach ? 'Bad environment state detected after running this test!\n\n' : '') +
+          'The PluginRequireInstance was not properly cleaned up in a previous test. Please check that the failing ' +
+          'test is running PluginRequireProvider.destroyPluginHooks() or cleans up PluginRequireProvider.mInstance ' +
+          'before exiting.',
+      );
+    }
+  };
+
+  /**
+   * This function is responsible for overriding the require interface with
+   * our dummy require. It will ensure that normal requires still happen as usual
+   * while test requires don't try to load anything.
+   */
+  const getMockedRequire = () => {
+    //@ts-ignore
+    return Module.prototype.require = jest.fn(function(...args: any[]) {
+      if (args[1] === testRequireIndicator) {
+        // eslint-disable-next-line no-invalid-this
+        return this;
+      } else {
+        // eslint-disable-next-line no-invalid-this
+        return originalRequire.apply(this as any, args);
+      }
+    });
+  };
+
+  // Gets a reference to the original require before each test
+  beforeEach(() => {
+
+    originalRequire = Module.prototype.require;
+    checkForCleanEnvironment();
+  });
+
+  // Restores the original require
+  afterEach(() => {
+    // Ensure that the proper module loader is set back as the prototype.
+    Module.prototype.require = originalRequire;
+    mPluginRequireProvider.mInstance = undefined as any
+    checkForCleanEnvironment(true);
+  });
+
+  it('should override and cleanup the module require', () => {
+    // Inject a dummy require so we can check it.
+    const mockedRequire = getMockedRequire();
+
+    PluginRequireProvider.createPluginHooks(['test']);
+
+    // Checks that we have indeed overridden the module require
+    expect(mPluginRequireProvider.mInstance.origRequire).toBe(mockedRequire);
+    expect(Module.prototype.require).not.toBe(mockedRequire);
+    expect(mPluginRequireProvider.mInstance.modules).toEqual(['test']);
+
+    // Perform the cleanup
+    PluginRequireProvider.destroyPluginHooks();
+
+    expect(Module.prototype.require).toBe(mockedRequire);
+    expect(mPluginRequireProvider.mInstance).toBeUndefined();
+  });
+
+  describe('environment stability', () => {
+    it('should guard against adding multiple hooks', () => {
+      expect(() => {
+        PluginRequireProvider.createPluginHooks(['test']);
+        PluginRequireProvider.createPluginHooks(['test']);
+      }).toThrow(PluginErrors.PluginRequireAlreadyCreatedError);
+
+      PluginRequireProvider.destroyPluginHooks();
+    });
+
+    // eslint-disable-next-line quotes
+    it("should guard against destroying hooks that haven't been created", () => {
+      expect(() => {
+        PluginRequireProvider.destroyPluginHooks();
+      }).toThrow(PluginErrors.PluginRequireNotCreatedError);
+    });
+  });
+
+  describe('injection tests', () => {
+    const MAX_NPM_PACKAGE_NAME_LENGTH = 214;
+
+    it('should properly prepare modules for injection into a regular expression', () => {
+      expect(mPluginRequireProvider.sanitizeExpression('abcd')).toEqual('abcd');
+      expect(mPluginRequireProvider.sanitizeExpression('this.is.a.test')).toEqual('this\\.is\\.a\\.test');
+    });
+
+    describe('use proper regex format', () => {
+      /**
+       * This function will escape modules for testing purposes. Goes through
+       * the same process as the real module loader for consistency. The
+       * sanitize function is tested earlier in the unit tests.
+       *
+       * @param modules An array of modules to escape
+       *
+       * @returns An array of escaped modules
+       */
+      const escapeModules = (modules: string[]) => {
+        const escaped: string[] = [];
+
+        for (const module of modules) {
+          escaped.push(mPluginRequireProvider.sanitizeExpression(module));
+        }
+
+        return escaped;
+      };
+
+      // We don't need to worry about checking anything with a special character
+      // including the | since an npm package must be url safe :)
+      const tests = {
+        '1 module': ['this-is-a-test'],
+        '3 modules': ['this-is-a-test', '@another/module', 'and_another_one'],
+        '3 modules of max length': [
+          generateRandomAlphaNumericString(MAX_NPM_PACKAGE_NAME_LENGTH).toLowerCase(),
+          generateRandomAlphaNumericString(MAX_NPM_PACKAGE_NAME_LENGTH).toLowerCase(),
+          generateRandomAlphaNumericString(MAX_NPM_PACKAGE_NAME_LENGTH).toLowerCase(),
+        ],
+        '1 module with periods': ['test.with.periods.for.package'],
+      };
+
+      // Loop through the tests object so we can quickly check that
+      // the requires are correct
+      Object.entries(tests).forEach(([testName, injectedModules]) => {
+        it(`should pass test: ${testName}`, () => {
+          // Inject a dummy require so we can check it.
+          getMockedRequire();
+
+          const modulesForRegex = escapeModules(injectedModules);
+
+          // Inject our test modules
+          PluginRequireProvider.createPluginHooks(injectedModules);
+
+          try {
+            expect(mPluginRequireProvider.mInstance.regex).toEqual(new RegExp(`^(${modulesForRegex.join('|')})(?:\\/.*)?$`, 'gm'));
+          } catch (e) {
+            PluginRequireProvider.destroyPluginHooks();
+            throw e;
+          }
+
+          PluginRequireProvider.destroyPluginHooks();
+        });
+      });
+    });
+
+    describe('module injection', () => {
+      interface ITestStructure {
+        /**
+         * The modules to provide to the test.
+         */
+        modules: string[];
+        shouldRequireDirectly: string[];
+      }
+
+      const randomModuleMaxLength = [
+        generateRandomAlphaNumericString(MAX_NPM_PACKAGE_NAME_LENGTH).toLowerCase(),
+        generateRandomAlphaNumericString(MAX_NPM_PACKAGE_NAME_LENGTH).toLowerCase(),
+        generateRandomAlphaNumericString(MAX_NPM_PACKAGE_NAME_LENGTH).toLowerCase(),
+      ];
+
+      const tests: { [key: string]: ITestStructure } = {
+        '1 module': {
+          modules: ['this-is-a-test'],
+          shouldRequireDirectly: ['./anything', 'this-is-a-test-module', 'this-is', '@zowe/chat', 'this-is-a-tests'],
+        },
+        '3 modules': {
+          modules: ['this-is-a-test', '@another/module', 'and_another_one'],
+          shouldRequireDirectly: ['./anything', '@another/module2', './another/module', '@scope/and_another_one'],
+        },
+        '3 modules of max length': {
+          modules: randomModuleMaxLength,
+          shouldRequireDirectly: [
+            './anything/goes/here',
+            randomModuleMaxLength[0].substr(15),
+            randomModuleMaxLength[1].substr(200),
+            randomModuleMaxLength[2].substr(59),
+          ],
+        },
+        '1 module with periods': {
+          modules: ['test.with.periods.for.package'],
+          shouldRequireDirectly: [
+            './',
+            'some-random-module',
+            'test-with-periods-for-package', // This one might break the regex with .'s
+            './test.with.periods.for.package',
+          ],
+        },
+      };
+
+      Object.entries(tests).forEach(([testName, testData]) => {
+        describe(`${testName}`, () => {
+          describe('should redirect to the original require', () => {
+            for (const requireDirect of testData.shouldRequireDirectly) {
+              it(`passes with value "${requireDirect}"`, () => {
+                const thisObject = 'This string gets attached as the this to require so we can track if it got called correctly';
+                const mockedRequire = getMockedRequire();
+
+                PluginRequireProvider.createPluginHooks(testData.modules);
+
+                try {
+                  // If all went well, this should be dispatched to the mockedRequire
+                  // which should abort the require due to the input being an object.
+                  expect(modulePrototype.require.call(thisObject, requireDirect, testRequireIndicator)).toBe(thisObject);
+
+                  expect(mockedRequire).toHaveBeenCalledTimes(1);
+                  expect(mockedRequire).toHaveBeenCalledWith(requireDirect, testRequireIndicator);
+                } catch (e) {
+                  PluginRequireProvider.destroyPluginHooks();
+
+                  throw e;
+                }
+
+                PluginRequireProvider.destroyPluginHooks();
+              });
+            }
+          });
+
+          describe('should redirect to an injected module', () => {
+            for (const module of testData.modules) {
+              it(`passes with module "${module}"`, () => {
+                const thisObject = 'This should not be returned';
+                const mockedRequire = getMockedRequire();
+
+                // The host package can't match the module for the purpose of this test
+                // that test will come at a later date.
+                const nonMatchingHostPackage = module.split('').reverse().join('');
+
+                // Account for the possibility that someone made a palindrome
+                expect(module).not.toEqual(nonMatchingHostPackage);
+
+                PluginRequireProvider.createPluginHooks(testData.modules);
+
+                try {
+                  // The return should be the main module as that is what the module loader does.
+                  expect(modulePrototype.require.call(thisObject, module, testRequireIndicator)).toBe(process.mainModule);
+
+                  // Expect that the require was just called with the module
+                  expect(mockedRequire).toHaveBeenCalledTimes(1);
+                  expect(mockedRequire).toHaveBeenCalledWith(module, testRequireIndicator);
+
+                  // Reset the call stack of the require
+                  mockedRequire.mockClear();
+
+                  // Do it again but to a submodule import
+                  const submodule = `${module}/submodule/import`;
+                  expect(modulePrototype.require.call(thisObject, submodule, testRequireIndicator)).toBe(process.mainModule);
+
+                  // Expect that the require was just called with the submodule
+                  expect(mockedRequire).toHaveBeenCalledTimes(1);
+                  expect(mockedRequire).toHaveBeenCalledWith(submodule, testRequireIndicator);
+                } catch (e) {
+                  PluginRequireProvider.destroyPluginHooks();
+
+                  throw e;
+                }
+
+                // Clean up after ourselves
+                PluginRequireProvider.destroyPluginHooks();
+              });
+            }
+          });
+
+          describe('should redirect to the proper host package', () => {
+            for (const module of testData.modules) {
+              it(`passes with module ${module}`, () => {
+
+                const thisObject = 'This should not be returned';
+                const mockedRequire = getMockedRequire();
+
+                PluginRequireProvider.createPluginHooks(testData.modules);
+
+                try {
+                  expect(modulePrototype.require.call(thisObject, module, testRequireIndicator)).toBe(process.mainModule);
+
+                  expect(mockedRequire).toHaveBeenCalledTimes(1);
+                  expect(mockedRequire).toHaveBeenCalledWith(module, testRequireIndicator);
+                } catch (e) {
+                  PluginRequireProvider.destroyPluginHooks();
+                  throw e;
+                }
+
+                PluginRequireProvider.destroyPluginHooks();
+              });
+            }
+          });
+
+          describe('should redirect to the proper host package submodule import', () => {
+            for (const module of testData.modules) {
+              it(`passes with module ${module}`, () => {
+
+                const thisObject = 'This should not be returned';
+                const mockedRequire = getMockedRequire();
+                const submoduleImport = '/some/submodule/import';
+
+                PluginRequireProvider.createPluginHooks(testData.modules);
+
+                try {
+                  expect(modulePrototype.require.call(thisObject, module + submoduleImport, testRequireIndicator)).toBe(
+                    process.mainModule,
+                  );
+
+                  expect(mockedRequire).toHaveBeenCalledTimes(1);
+                  expect(mockedRequire).toHaveBeenCalledWith(module + submoduleImport, testRequireIndicator);
+                } catch (e) {
+                  PluginRequireProvider.destroyPluginHooks();
+                  throw e;
+                }
+
+                PluginRequireProvider.destroyPluginHooks();
+              });
+            }
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/chat/src/main.ts
+++ b/packages/chat/src/main.ts
@@ -9,6 +9,7 @@
  */
 
 import { chatBot } from './bot/ChatBot';
+import { PluginRequireProvider } from './plugins/PluginRequireProvider';
 // import { Logger } from "./utils/Logger";
 
 // // Logger must be initialized for future class initialization. Uses AppConfig.
@@ -16,6 +17,8 @@ import { chatBot } from './bot/ChatBot';
 
 // // Start chat bot. Requires AppConfig and Logger.
 // logger.info("Initializing Zowe Chat Bot");
+
+PluginRequireProvider.createPluginHooks(['i18next', '@zowe/chat', '@zowe/imperative']);
 
 //
 chatBot.run();

--- a/packages/chat/src/plugins/PluginErrors.ts
+++ b/packages/chat/src/plugins/PluginErrors.ts
@@ -1,0 +1,21 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+export class PluginRequireNotCreatedError extends Error {
+  constructor() {
+    super('Hooks have not been initialized. Please use `PluginRequireProvider.createPluginHooks(...)` first');
+  }
+}
+
+export class PluginRequireAlreadyCreatedError extends Error {
+  constructor() {
+    super('Plugin requires have already been overridden. Cannot add a second hook!');
+  }
+}

--- a/packages/chat/src/plugins/PluginRequireProvider.ts
+++ b/packages/chat/src/plugins/PluginRequireProvider.ts
@@ -1,0 +1,180 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+import Module = require('module');
+import path = require('path');
+import { EnvironmentVariable } from '../settings/EnvironmentVariable';
+import * as PluginErrors from './PluginErrors';
+
+/**
+ * This class will allow imperative to intercept calls by plugins so that it can
+ * provide them with the runtime instance of imperative / base cli when necessary.
+ *
+ * @future Currently this loader is only available from Imperative's internals but
+ *         work could be done to make this a true standalone package that either
+ *         Imperative depends on or ships as a separate folder under packages.
+ *
+ * @example <caption>Proper Use of the Module Loader</caption>
+ * // Ideally this is the first thing that gets called by your application; however,
+ * // the module loader can be created and destroyed at any point by your application.
+ *
+ * // Initializing the loader
+ * PluginRequireProvider.createPluginHooks(["module-a", "module-b"]);
+ *
+ * // Now in all places of the application, module-a and module-b will be loaded
+ * // from the package location of process.mainModule (I.E the Host Package). This
+ * // is useful when the Host Package has some sort of plugin infrastructure that
+ * // might require modules to be injected to the plugins.
+ *
+ * // So this will always be the Host Package module regardless of where it was
+ * // called from.
+ * require("module-a");
+ *
+ * // But this will act as normal
+ * require("module-c");
+ *
+ * // It is not necessary to cleanup the module loader before exiting. Your
+ * // application lifecycle may require it to be brought up and down during the
+ * // course of execution. With this in mind, a method has been provided to remove
+ * // the hooks created by `createPluginHooks`.
+ *
+ * // Calling this
+ * PluginRequirePriovider.destroyPluginHooks();
+ *
+ * // Will now cause this to act as normal regardless of how it would have been
+ * // injected before.
+ * require("module-b");
+ *
+ */
+export class PluginRequireProvider {
+  /**
+   * Create hooks for the specified modules to be injected at runtime.
+   *
+   * @param modules An array of modules to inject from the host application.
+   *
+   * @throws {PluginRequireAlreadyCreatedError} when hooks have already been added.
+   */
+  public static createPluginHooks(modules: string[]) {
+    if (PluginRequireProvider.mInstance != null) {
+      throw new PluginErrors.PluginRequireAlreadyCreatedError();
+    }
+
+    this.mInstance = new PluginRequireProvider(modules);
+  }
+
+  /**
+   * Restore the default node require hook.
+   *
+   * @throws {PluginRequireNotCreatedError} when hooks haven't been added.
+   */
+  public static destroyPluginHooks() {
+    if (PluginRequireProvider.mInstance == null) {
+      throw new PluginErrors.PluginRequireNotCreatedError();
+    }
+
+    // Set everything back to normal
+    Module.prototype.require = PluginRequireProvider.mInstance.origRequire;
+    PluginRequireProvider.mInstance = undefined;
+  }
+
+  /**
+   * Reference to the static singleton instance.
+   */
+  private static mInstance: PluginRequireProvider;
+
+  /**
+   * This regular expression is used by the module loader to
+   * escape any valid characters that might be present in provided
+   * modules.
+   */
+  private static sanitizeExpression(module: string) {
+    /*
+     * This replaces special characters that might be present in a regular expression and an
+     * npm package name.
+     *
+     * @see https://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript
+     */
+    return module.replace(/\./g, '\\$&');
+  }
+
+  /**
+   * Reference to the original require function.
+   */
+  private origRequire: typeof Module.prototype.require;
+
+  /**
+   * Reference to the regular expression used to match modules.
+   *
+   * This property was added to make testing easier.
+   */
+  private readonly regex: RegExp;
+
+  /**
+   * Construct the class and create hooks into require.
+   * @param modules The modules that should be injected from the runtime instance
+   */
+  private constructor(private readonly modules: string[]) {
+    const hostPackageName = '@zowe/chat';
+    const hostPackageRoot = EnvironmentVariable.ZOWE_CHAT_HOME + path.sep + 'zoweChat';
+
+    // We must remember to escape periods from modules for regular expression
+    // purposes.
+    const internalModules: string[] = [];
+
+    for (const module of this.modules) {
+      internalModules.push(PluginRequireProvider.sanitizeExpression(module));
+    }
+
+    /*
+     * Check that the element (or module that we inject) is present at position 0.
+     * It was designed this way to support submodule imports.
+     *
+     * Example:
+     * If modules = ["@zowe/imperative"]
+     *    request = "@zowe/imperative/lib/errors"
+     */
+    // This regular expression will match /(@zowe\/imperative)/.*/
+    /*
+     * The ?: check after the group in the regular expression is to explicitly
+     * require that a submodule import has to match. This is to account for the
+     * case where one of the packages to be injected is some-test-module and
+     * we are requiring some-test-module-from-npm. Without the slash, that
+     * module is incorrectly matched and injected.
+     */
+    const regex = this.regex = new RegExp(`^(${internalModules.join('|')})(?:\\/.*)?$`, 'gm');
+    const origRequire = this.origRequire = Module.prototype.require;
+
+    // Timerify the function if needed
+    // Gave it a name so that we can more easily track it
+    Module.prototype.require = function PluginModuleLoader(...args: any[]) {
+      // Check to see if the module should be injected
+      const request: string = args[0];
+      const doesUseOverrides = request.match(regex);
+
+      if (doesUseOverrides) {
+        // Next we need to check if this is the root module. If so, then
+        // we need to remap the import.
+        if (request.startsWith(hostPackageName)) {
+          if (request === hostPackageName) {
+            args[0] = '.' + path.sep;
+          } else {
+            args[0] = `${hostPackageRoot}${path.sep}${request.substr(hostPackageName.length)}`;
+          }
+        }
+
+        // Inject it from the main module dependencies
+        return origRequire.apply(process.mainModule, args);
+      } else {
+        // Otherwise use the package dependencies
+        return origRequire.apply(this, args);
+      }
+    } as typeof Module.prototype.require;
+  }
+}

--- a/packages/zos/package.json
+++ b/packages/zos/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@zowe/core-for-zowe-sdk": "^7.2.2",
     "@zowe/zos-jobs-for-zowe-sdk": "^7.2.2",
+    "@zowe/zos-files-for-zowe-sdk": "^7.2.2",
     "@zowe/zosmf-for-zowe-sdk": "^7.2.2",
     "@zowe/zos-console-for-zowe-sdk": "^7.2.2"
   },
@@ -60,7 +61,6 @@
   "peerDependencies": {
     "@zowe/chat": "*",
     "@zowe/imperative": "*",
-    "@zowe/zos-files-for-zowe-sdk": "*",
     "i18next": "*"
   },
   "bundledDependencies": [],

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "lib": ["esnext"],
+    "experimentalDecorators": true,
+    "target": "es2015",
+    "module": "commonjs",
+    "noEmit": true,
+    "declaration": true,
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "outDir": "./lib",
+    "preserveConstEnums": true,
+    "removeComments": false,
+    "pretty": true,
+    "sourceMap": true,
+    "newLine": "lf"
+  },
+  "typeRoots": ["./node_modules/@types"],
+  "include": ["**/__tests__/*"],
+  "exclude": ["lib", "node_modules", "**/__mocks__/*"]
+}


### PR DESCRIPTION
# Description

This PR ports dynamic module resolution from Imperative to Zowe Chat, modified to better suit Zowe Chat's needs by making the code less general - Imperative needed to support more arbitrary paths/naming structures which isn't the case for the Chat server.

Linked to #188 

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The tests in the area I was working on leverage nested `describe` blocks where appropriate
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/zowe-chat/blob/main/CONTRIBUTING.md)