### PR TITLE
build: replace set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Get NPM Version
         id: npm-version
-        run: echo "::set-output name=number::$(npm --version)"
+        run: echo "number=$(npm --version)" >> $GITHUB_OUTPUT
 
       - name: Use NPM v8
         id: npm8


### PR DESCRIPTION
# Description

Addresses a deprecation by Github, see issue https://github.com/zowe/zowe-install-packaging/issues/3378 